### PR TITLE
Salto Deployment: provar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+## [provar](https://app.salto.io/orgs/84e41f56-7290-4005-85ea-2b1daf513340/envs/421e8580-6149-4ce8-a304-2d79afa136b2/deployments/369154ed-10be-4d86-b35f-dc57833b39ec)
+
+Source Environment: [Pablo Sandbox](https://app.salto.io/orgs/84e41f56-7290-4005-85ea-2b1daf513340/envs/9acd5bb6-aedd-4d2e-9e0c-4ca3305ab117) 
+
+Target Environment: [Integration](https://app.salto.io/orgs/84e41f56-7290-4005-85ea-2b1daf513340/envs/421e8580-6149-4ce8-a304-2d79afa136b2) 
+
+Author: Pablo Gonzalez
+
+To include additional edits in this deployment, commit edits to the PR after branch.

--- a/envs/Integration/static-resources/salesforce/Records/ApexClass/AtFutureRecipes.cls
+++ b/envs/Integration/static-resources/salesforce/Records/ApexClass/AtFutureRecipes.cls
@@ -16,9 +16,6 @@ public with sharing class AtFutureRecipes {
      */
     @testVisible
     private static Boolean testCircuitBreaker = false;
-    private static Boolean WhatIsThis = true;
-    private static String what = 'Git is complicated';
-  
     /**
      * @description Method demonstrates the @future annotation without the
      * (callout=true) adendum. This method will be run in a different Apex

--- a/envs/Integration/static-resources/salesforce/Records/ApexClass/AtFutureRecipes_Tests.cls
+++ b/envs/Integration/static-resources/salesforce/Records/ApexClass/AtFutureRecipes_Tests.cls
@@ -7,6 +7,7 @@ private inherited sharing class AtFutureRecipes_Tests {
          * when you call asynchronous code within Test.startTest() and Test.stopTest() the test
          * runner forces the asynchronous code to run synchronously.
          */
+        System.debug(true);
         Test.startTest();
         AtFutureRecipes.atFutureMethodWithoutCalloutPrivileges('Hello World');
         Test.stopTest();


### PR DESCRIPTION

Salto [deployment](https://app.salto.io/orgs/84e41f56-7290-4005-85ea-2b1daf513340/envs/421e8580-6149-4ce8-a304-2d79afa136b2/deployments/369154ed-10be-4d86-b35f-dc57833b39ec) from Pablo Sandbox to Integration.




