### PR TITLE
Salto Deployment: rollback to oct 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+## [rollback to oct 26](https://app.salto.io/orgs/84e41f56-7290-4005-85ea-2b1daf513340/envs/421e8580-6149-4ce8-a304-2d79afa136b2/deployments/16fe1271-0b1f-4a9b-8f67-942eff075b11)
+
+Source Environment: Snapshot from 10/26/2023 @ 9:42 am of [Integration](https://app.salto.io/orgs/84e41f56-7290-4005-85ea-2b1daf513340/envs/421e8580-6149-4ce8-a304-2d79afa136b2)
+
+Target Environment: [Integration](https://app.salto.io/orgs/84e41f56-7290-4005-85ea-2b1daf513340/envs/421e8580-6149-4ce8-a304-2d79afa136b2) 
+
+Author: Pablo Gonzalez
+
+To include additional edits in this deployment, commit edits to the PR after branch.

--- a/envs/Integration/salesforce/Objects/Account/AccountCustomFields.nacl
+++ b/envs/Integration/salesforce/Objects/Account/AccountCustomFields.nacl
@@ -41,11 +41,6 @@ type salesforce.Account {
         default = false
         label = "Medium"
       },
-      {
-        fullName = "Too low"
-        default = false
-        label = "Too low"
-      },
     ]
     sorted = false
     restricted = false


### PR DESCRIPTION

Salto [deployment](https://app.salto.io/orgs/84e41f56-7290-4005-85ea-2b1daf513340/envs/421e8580-6149-4ce8-a304-2d79afa136b2/deployments/16fe1271-0b1f-4a9b-8f67-942eff075b11) from an older version of Integration (10/26/2023 @ 9:42 am) to Integration.




